### PR TITLE
Enable Dependabot for Dockerfiles

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,12 @@ updates:
     # Raise all npm pull requests with reviewers
     reviewers:
       - "btlogy"
+  # Keep Docker base images up to date
+  - package-ecosystem: "docker"
+    directory: "/docker"
+    schedule:
+      interval: "daily"
+      time: "08:30"
+    # Raise all docker pull requests with reviewers
+    reviewers:
+      - "btlogy"


### PR DESCRIPTION
To test how to use Dependabot for Docker base images (see LeastAuthority/magic-wormhole-docker#27)