### PR TITLE
Switch and bump docker-cache action to use new GH cache

### DIFF
--- a/.github/workflows/ansible.yml
+++ b/.github/workflows/ansible.yml
@@ -33,7 +33,7 @@ jobs:
           docker compose version
 
       - name: Cache docker images
-        uses: ScribeMD/docker-cache@0.3.3
+        uses: AndreKurait/docker-cache@0.6.0
         with:
           key: |
             docker-${{ runner.os }}-${{ hashFiles(

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v3    
 
       - name: Cache docker images
-        uses: ScribeMD/docker-cache@0.3.3
+        uses: AndreKurait/docker-cache@0.6.0
         with:
           key: |
             docker-${{ runner.os }}-${{ hashFiles(


### PR DESCRIPTION
Part of LeastAuthority/it-ops#713 and LeastAuthority/it-ops#760